### PR TITLE
Remove an unnecessary GitLab file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,0 @@
-pages:
-    stage: deploy
-    script:
-        - mv __site public
-    artifacts:
-        paths:
-            - public
-    only:
-        - master


### PR DESCRIPTION
This removes a file we don't need because we don't use GitLab.

Fixes #3 