### PR TITLE
Temporarily remove the logo from the bottom-left corner

### DIFF
--- a/_layout/pgwrap.html
+++ b/_layout/pgwrap.html
@@ -98,11 +98,11 @@
             <li class="menu-list-item"><a href="/programming/computing/viz/"         class="menu-list-link {{ispage /programming/computing/viz/}}active{{end}}">5.9. Plotting and Visualization</a>
           </ul>
       </ul>
-    <div class="footer">
+    <!-- <div class="footer">
       <a href = "https://www.brown.edu/academics/medical/about-us/research/centers-institutes-and-programs/biomedical-informatics/" target="_blank">
         <img src = "/assets/bcbi_logo.png" alt = "Brown Center for Biomedical Informatics">
       </a>
-    </div>
+    </div> -->
   </div>
   <!-- CONTENT -->
   <div class="main">


### PR DESCRIPTION
This PR removes the logo. We can add it back once we figure out the clash between the logo and the menu.