### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+


### PR DESCRIPTION
Several students have expressed interest in contributing to the BIDSS manual. I'm not sure if any of them are working from a Windows environment, but just in case, I think it makes sense to enforce unix-style line endings at the reposititory level, rather than require them to enforce this on their local machines.

If someone edits a file on Windows, all the line endings get converted by default. That could possibly cause an error somewhere, but the main concern is that this interferes with tracking line changes, since all the lines get updated.

Also, I'm not sure if there are some binary files that need to be excluded from `.gitattributes`.