### PR TITLE
Ignore vim backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,16 @@ docs/build/
 docs/site/
 node_modules/
 
+# vim
+*.swp
+
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
 .DS_Store
 .Rhistory
 Icon
-Icon
+Icon
 Manifest.toml
 deps/build.log
 deps/deps.jl


### PR DESCRIPTION
Vim creates backup `.swp` files that shouldn't be merged into the main branch, so I've updated `.gitignore`.

Also, I took one set of carriage returns off the `Icon` entries. Otherwise, GitHub wanted to convert the entire file to CRLF endings.